### PR TITLE
Use post

### DIFF
--- a/app/pengo.js
+++ b/app/pengo.js
@@ -44,12 +44,12 @@ const pengo =  {
 
       // /pengo rant or whatever it's going to be called
       else if (request.body.text === 'rant') {
-        let responseText = '<img src="rant.png">';
+        let responseURL = "https://pengo.herokuapp.com/rant.png";
         let data = {
           "response_type": "in_channel", // public to the channel
           "attachments": [
             {
-              "text": responseText,
+              "text": responseURL,
               "color": "warning"
             }
           ]
@@ -63,7 +63,7 @@ const pengo =  {
         let helpMessage =
         '"/pengo" get a random quote from the Progmatic Programmer \n' +
         '"/pengo [ID]" you can specifiy a quote by ID number \n' +
-        '"/pengo rant" a JPEG with a special quote';
+        '"/pengo rant" get the most important piece of advice';
 
         let data = {
           "response_type": "in_channel", // public to the channel

--- a/app/pengo.js
+++ b/app/pengo.js
@@ -61,7 +61,7 @@ const pengo =  {
       // /pengo help
       else if (request.body.text === 'help'){
         let helpMessage =
-        '"/pengo" get a random quote from the Progmatic Programmer \n' +
+        '"/pengo" get a random quote from the Pragmatic Programmer \n' +
         '"/pengo [ID]" you can specifiy a quote by ID number \n' +
         '"/pengo rant" get the most important piece of advice';
 

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@
 /* ========================== VENDOR DEPENDENCIES ========================== */
 
 const express  = require('express');
-//const bodyParser = require('body-parser');
+const bodyParser = require('body-parser');
 const mongoose = require('mongoose');
 const dotenv   = require('dotenv').config();
 const app      = express();
@@ -20,8 +20,8 @@ const getQuote = require('./app/getQuote');
 const PORT = process.env.PORT || 3000;
 const url = process.env.MONGOLAB_URI;
 
-//app.use(bodyParser.json());
-//app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
 
 
 /* ============================ DATABASE CONNECT =========================== */
@@ -39,40 +39,7 @@ db.once('open', function() {
 
 app.use(express.static('images')); // for fetching rant image
 
-app.get('/',function(req,res){
-  // req.body is for testing.  Dump when Pengo goes live.
-  req.body = 
-  {
-    "token" : "gIkuvaNzQIHg97ATvDxqgjtO",
-    "team_id" : "T0001",
-    "team_domain" : "example",
-    "channel_id" : "C2147483705",
-    "channel_name" : "jones",
-    "user_id" : "U2147483697",
-    "user_name" : "peterjmartinson",
-    "command" : "/pengo",
-    "text" : "",
-    "response_url" : "https://hooks.slack.com/commands/1234/5678"
-  }
-  pengo.handleCommand(req, res);
-});
-
-app.get('/:quote_id', function(req,res){
-console.log(req.params.quote_id);
-req.body = 
-{
-  "token" : "gIkuvaNzQIHg97ATvDxqgjtO",
-  "team_id" : "T0001",
-  "team_domain" : "example",
-  "channel_id" : "C2147483705",
-  "channel_name" : "jones",
-  "user_id" : "U2147483697",
-  "user_name" : "peterjmartinson",
-  "command" : "/pengo",
-  "text" : req.params.quote_id,
-  "response_url" : "https://hooks.slack.com/commands/1234/5678"
-}
-  // console.log(req.body);
+app.post('/',function(req,res){
   pengo.handleCommand(req, res);
 });
 


### PR DESCRIPTION
Two changes were made, which impart *full functionality* to the slash command in Slack:  
1. POST instead of GET  
- Slack's GET requests do not send a request.body.  In other words, the app cannot capture any command arguments.  
- Slack's POST requests, on the other hand, *do* include a body.  
2. Image link instead of html tag  
- Need to respond with the actual http address of the image, and attach it to `image_url`.