### PR TITLE
Add bash webscraper

### DIFF
--- a/app/getCommand.js
+++ b/app/getCommand.js
@@ -1,0 +1,64 @@
+/* 
+ * getCommand(command, callback)
+ * 
+ * pass a Bash command to getCommand, and receive
+ * the main parts of the relevant man page!
+ * 
+ * Author: Peter Martinson
+ * Date:   March 27, 2017
+*/
+
+
+const request = require('request'),
+      cheerio = require('cheerio'),
+      baseURL = 'http://man.he.net/man1/';
+
+// get the command text from the URL
+var fetchCommand = function(command, callback) {
+  var mainURL = baseURL + command;
+  request(mainURL, function(error, response, html) {
+    if (error) callback(error);
+    var $ = cheerio.load(html);
+    callback(null, $('pre').html());
+  });
+}
+
+module.exports = function(command, callback) {
+  fetchCommand(command, function(error, man) {
+    if (error) callback(error);
+
+    var commandArray = man.split('\n'),
+        toc          = [],
+        sections     = [];
+
+    // create TOC numbers
+    commandArray.forEach(function(element, index) {
+      if ( /^[A-Z]/.test(element) ) {
+        toc.push(index);
+      }
+    });
+
+    // create TOC section labels
+    toc.forEach(function(element) {
+      sections.push(commandArray[element]);
+    });
+
+    function createSection(title) {
+      return commandArray.filter(function(element, index) {
+        var sectionIndex    = toc[sections.indexOf(title.toUpperCase())];
+        var nextSectionIndex = toc[sections.indexOf(title.toUpperCase())+1];
+        if ( index > sectionIndex && index < nextSectionIndex ) {
+          return element;
+        }
+      }).join('\n');
+    }
+
+    callback(null, {
+      synopsis    : createSection('synopsis'),
+      description : createSection('description'),
+      options     : createSection('options'),
+      examples    : createSection('examples')
+    });
+  });
+}
+

--- a/app/pengo.js
+++ b/app/pengo.js
@@ -10,7 +10,8 @@
 
 // one function to handle all slack commands (subject to change if needed)
 
-const getQuote = require('./getQuote');
+const getQuote   = require('./getQuote'),
+      getCommand = require('./getCommand');
 
 const pengo =  {
   handleCommand: function(request, response) {
@@ -81,21 +82,25 @@ const pengo =  {
 // ================ Begin Command Line Help
 
       else if ( /bash [\w\-\+]+$/mig.test(request.body.text) ) {
-        let responseText =
-        'You are asking for a command!\n' +
-        'The command name is: ' +
-        request.body.text.substring(5);
+        let footerText =
+          'You are asking for a command!\n' +
+          'The command name is: ' +
+          request.body.text.substring(5);
+        getCommand(request.body.text.substring(5), function(err, man) {
+          if (err) console.error(err);
 
-        let data = {
-          "response_type": "in_channel", // public to the channel
-          "attachments": [
-            {
-              "text": responseText,
-              "color": "good"
-            }
-          ]
-        }
-        response.send(data);
+          let data = {
+            "response_type": "in_channel", // public to the channel
+            "attachments": [
+              {
+                "text": man.synopsis,
+                "color": "good",
+                "footer": footerText
+              }
+            ]
+          }
+          response.send(data);
+        });
       }
 
 // ================== End Command Line Help

--- a/app/pengo.js
+++ b/app/pengo.js
@@ -80,8 +80,6 @@ const pengo =  {
 
 // ================ Begin Command Line Help
 
-      // else if ( /bash [\w-+]+$/mig.test(request.body.text)
-      //        && (request.body.text.match(/bash [\w-+]+$/gmi)).length === 1 ) {
       else if ( /bash [\w\-\+]+$/mig.test(request.body.text) ) {
         let responseText =
         'You are asking for a command!\n' +

--- a/app/pengo.js
+++ b/app/pengo.js
@@ -1,10 +1,11 @@
 'use strict';
 
-// TODO
 // /pengo - respond with random tip text from database
 // /pengo [ID] - respond with tip text from database specified by ID
 // /pengo rant - resond with special JPEG
 // /pengo help - responds with helpful tips on using /pengo commands
+// TODO
+// /pengo bash [command] - respond with reference from http://man.he.net
 
 
 // one function to handle all slack commands (subject to change if needed)

--- a/app/pengo.js
+++ b/app/pengo.js
@@ -78,6 +78,30 @@ const pengo =  {
         response.send(data);
       }
 
+// ================ Begin Command Line Help
+
+      // else if ( /bash [\w-+]+$/mig.test(request.body.text)
+      //        && (request.body.text.match(/bash [\w-+]+$/gmi)).length === 1 ) {
+      else if ( /bash [\w\-\+]+$/mig.test(request.body.text) ) {
+        let responseText =
+        'You are asking for a command!\n' +
+        'The command name is: ' +
+        request.body.text.substring(5);
+
+        let data = {
+          "response_type": "in_channel", // public to the channel
+          "attachments": [
+            {
+              "text": responseText,
+              "color": "good"
+            }
+          ]
+        }
+        response.send(data);
+      }
+
+// ================== End Command Line Help
+
       // /pengo (wrong text)
       else {
         let errorMessage = "Sorry, looks like you typed something in wrong. Try /pengo help.";

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   "homepage": "https://github.com/peterjmartinson/PengoBot#readme",
   "dependencies": {
     "body-parser": "^1.17.1",
+    "cheerio": "^0.22.0",
     "dotenv": "^4.0.0",
     "express": "^4.15.2",
-    "mongoose": "^4.8.6"
+    "mongoose": "^4.8.6",
+    "request": "^2.81.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -8,11 +8,13 @@ const mongoose = require('mongoose');
 const dotenv   = require('dotenv').config();
 const app      = express();
 
+const request    = require('request');
+const cheerio    = require('cheerio');
 
 /* =========================== LOCAL DEPENDENCIES ========================== */
 
 const pengo    = require('./app/pengo');
-const getQuote = require('./app/getQuote');
+const getQuote = require('./app/getQuote'); // is this needed here?
 
 
 /* ============================= GLOBAL CONFIG ============================= */


### PR DESCRIPTION
This thing is by no means complete, but should be pulled into the master branch to include the recent changes in master.  Overall, the only thing accomplished here is to get parts of a Bash command to display in Slack when called by `@pengo bash <command>`.

Specific issues addressed:
1. Add function `getCommand` that takes a Bash command from `@pengo bash <command>`, searches for it on http://man.he.net, and returns specific sections of the response to the caller.
2. Modify `pengo.js` to call `getCommand()` when the Slack argument is of the form `bash <command>`

To Do:
1. The output is not formatted in any way.  It should be.
2. Deal with huuuuuge sections (e.g. DESCRIPTION from gcc).
3. Friendly response when the command is not found.  Currently, nothing happens.